### PR TITLE
User reports

### DIFF
--- a/env/caravel_spef_mapping-mpw7.tcl
+++ b/env/caravel_spef_mapping-mpw7.tcl
@@ -106,8 +106,8 @@ set spef_mapping(padframe)                 ${SPEF_MAPPING_PREFIX}chip_io${SPEF_M
 set SPEF_MAPPING_PREFIX "$::env(CARAVEL_ROOT)/signoff/digital_pll/openlane-signoff/spef/"
 set spef_mapping(pll)                      ${SPEF_MAPPING_PREFIX}digital_pll${SPEF_MAPPING_POSTFIX}
 
-set SPEF_MAPPING_PREFIX "$::env(CARAVEL_ROOT)/signoff/simple_por/openlane-signoff/spef/"
-set spef_mapping(por)                      ${SPEF_MAPPING_PREFIX}simple_por${SPEF_MAPPING_POSTFIX}
+#set SPEF_MAPPING_PREFIX "$::env(CARAVEL_ROOT)/signoff/simple_por/openlane-signoff/spef/"
+#set spef_mapping(por)                      ${SPEF_MAPPING_PREFIX}simple_por${SPEF_MAPPING_POSTFIX}
 
 set SPEF_MAPPING_PREFIX "$::env(CARAVEL_ROOT)/signoff/xres_buf/openlane-signoff/spef/"
 set spef_mapping(rstb_level)               ${SPEF_MAPPING_PREFIX}xres_buf${SPEF_MAPPING_POSTFIX}

--- a/env/sky130A/config.tcl
+++ b/env/sky130A/config.tcl
@@ -15,13 +15,17 @@ set io_lef $::env(PDK_REF_PATH)/$io_library/lef/$io_library.lef
 set ef_io_lef $::env(PDK_REF_PATH)/$io_library/lef/$ef_io_library.lef
 set ef_cells_lef $::env(PDK_REF_PATH)/$std_cell_library/lef/$ef_cell_library.lef
 set sram_lef $::env(PDK_REF_PATH)/sky130_sram_macros/lef/sky130_sram_2kbyte_1rw1r_32x512_8.lef
+set hvl_lef $::env(PDK_REF_PATH)/$special_voltage_library/lef/$special_voltage_library.lef
+set hvl_techlef $::env(PDK_REF_PATH)/$special_voltage_library/techlef/${special_voltage_library}__$::env(RCX_CORNER).tlef
 
 set pdk(lefs) [list \
     $tech_lef \
+    $hvl_techlef \
     $cells_lef \
     $io_lef \
     $ef_cells_lef \
     $ef_io_lef \
+    $hvl_lef \
     $sram_lef
 ]
 

--- a/scripts/get_violations.py
+++ b/scripts/get_violations.py
@@ -1,8 +1,5 @@
-from pathlib import Path
 from report import Report
 import click
-import logging
-import sys
 
 
 @click.command()

--- a/scripts/get_violations.py
+++ b/scripts/get_violations.py
@@ -62,7 +62,7 @@ def main(input, append, type):
             stream.write(result)
     else:
         print(result)
-    print(round(max_vio, 2))
+    print(f'{max_vio:.2f}')
 
 
 if __name__ == "__main__":

--- a/scripts/get_worst.py
+++ b/scripts/get_worst.py
@@ -1,0 +1,24 @@
+from report import Report
+import click
+
+
+@click.command()
+@click.option(
+    "--input",
+    "-i",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="sta report",
+)
+def main(input):
+    report = Report(input)
+
+    max_vio = 0.00
+    for path in report.paths:
+        if path.slack < 0:
+            max_vio = min(max_vio, path.slack)
+
+    print(max_vio)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_worst.py
+++ b/scripts/get_worst.py
@@ -13,12 +13,12 @@ import click
 def main(input):
     report = Report(input)
 
-    max_vio = 0.00
+    max_vio = 0
     for path in report.paths:
         if path.slack < 0:
             max_vio = min(max_vio, path.slack)
 
-    print(max_vio)
+    print(f'{max_vio:.2f}')
 
 if __name__ == "__main__":
     main()

--- a/scripts/openroad/timing_top.tcl
+++ b/scripts/openroad/timing_top.tcl
@@ -98,62 +98,91 @@ run_puts_logs "report_checks \\
     "${logs_path}/max.rpt"
 lappend reports "${logs_path}/max.rpt"
 
-run_puts_logs "report_checks \\
-    -path_delay min \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group hk_serial_clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/hk_serial_clk-min.rpt"
-lappend reports "${logs_path}/hk_serial_clk-min.rpt"
+if {!$::env(TIMING_USER_REPORTS)} {
+    run_puts_logs "report_checks \\
+        -path_delay min \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group hk_serial_clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/hk_serial_clk-min.rpt"
+    lappend reports "${logs_path}/hk_serial_clk-min.rpt"
 
+    run_puts_logs "report_checks \\
+        -path_delay max \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group hk_serial_clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/hk_serial_clk-max.rpt"
+    lappend reports "${logs_path}/hk_serial_clk-max.rpt"
 
-run_puts_logs "report_checks \\
-    -path_delay max \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group hk_serial_clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/hk_serial_clk-max.rpt"
-lappend reports "${logs_path}/hk_serial_clk-max.rpt"
+    run_puts_logs "report_checks \\
+        -path_delay max \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group hkspi_clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/hkspi_clk-max.rpt"
+    lappend reports "${logs_path}/hkspi_clk-max.rpt"
 
-run_puts_logs "report_checks \\
-    -path_delay max \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group hkspi_clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/hkspi_clk-max.rpt"
-lappend reports "${logs_path}/hkspi_clk-max.rpt"
+    run_puts_logs "report_checks \\
+        -path_delay min \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group hkspi_clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/hkspi_clk-min.rpt"
+    lappend reports "${logs_path}/hkspi_clk-min.rpt"
 
-run_puts_logs "report_checks \\
-    -path_delay min \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group hkspi_clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/hkspi_clk-min.rpt"
-lappend reports "${logs_path}/hkspi_clk-min.rpt"
+    run_puts_logs "report_checks \\
+        -path_delay min \\
+        -through [get_cells soc] \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/soc-min.rpt"
+    lappend reports "${logs_path}/soc-min.rpt"
+
+    run_puts_logs "report_checks \\
+        -path_delay max \\
+        -through [get_cells soc] \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/soc-max.rpt"
+    lappend reports "${logs_path}/soc-max.rpt"
+}
 
 run_puts_logs "report_checks \\
     -path_delay min \\
@@ -168,7 +197,7 @@ run_puts_logs "report_checks \\
     "\
     "${logs_path}/clk-min.rpt"
 lappend reports "${logs_path}/clk-min.rpt"
-        
+
 run_puts_logs "report_checks \\
     -path_delay max \\
     -format full_clock_expanded \\
@@ -182,34 +211,6 @@ run_puts_logs "report_checks \\
     "\
     "${logs_path}/clk-max.rpt"
 lappend reports "${logs_path}/clk-max.rpt"
-
-run_puts_logs "report_checks \\
-    -path_delay min \\
-    -through [get_cells soc] \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/soc-min.rpt"
-lappend reports "${logs_path}/soc-min.rpt"
-
-run_puts_logs "report_checks \\
-    -path_delay max \\
-    -through [get_cells soc] \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/soc-max.rpt"
-lappend reports "${logs_path}/soc-max.rpt"
 
 run_puts_logs "report_checks \\
     -path_delay min \\
@@ -306,7 +307,7 @@ set min_vio "0"
 set violating_min_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_min $report]
-    if { [expr $vio != 0] } { 
+    if { [expr $vio != 0] } {
         set violating_min_reports "$violating_min_reports $report"
     }
     if { [expr $vio < $min_vio] } { set min_vio "$vio" }
@@ -320,10 +321,10 @@ set min_vio "0"
 set violating_max_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_max $report]
-    if { [expr $vio != 0] } { 
+    if { [expr $vio != 0] } {
         set violating_max_reports "$violating_max_reports $report"
     }
-    if { [expr $vio < $min_vio] } { set min_vio "$vio" } 
+    if { [expr $vio < $min_vio] } { set min_vio "$vio" }
 }
 if { "$min_vio" ne "0" } {
     set max_reg_to_reg_result "vio($min_vio)"
@@ -351,7 +352,7 @@ exec cat ${summary_report}-tmp-table ${summary_report} > ${summary_report}-tmp
 exec mv ${summary_report}-tmp ${summary_report}
 exec rm ${summary_report}-tmp-table
 
-report_parasitic_annotation 
+report_parasitic_annotation
 
 if { $missing_spefs } {
     puts "there are missing spefs. check the log for ALLOW_MISSING_SPEF"

--- a/scripts/openroad/timing_top.tcl
+++ b/scripts/openroad/timing_top.tcl
@@ -316,11 +316,11 @@ if {![catch {exec grep -q {max slew} $summary_report} err]} {
     set max_slew_result "vio($max_slew_value)"
 }
 
-if { [expr $worst_setup < "0"] } {
+if { [exec python3 -c "print($worst_hold<0)"] eq "True" } {
     set min_delay_result "vio($worst_hold)"
 }
 
-if { [expr $worst_hold < "0"] } {
+if { [exec python3 -c "print($worst_setup<0)"] eq "True" } {
     set max_delay_result "vio($worst_setup)"
 }
 
@@ -333,12 +333,12 @@ set min_vio "0"
 set violating_min_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_min $report]
-    if { [expr $vio != 0] } {
+    if { [exec python3 -c "print($vio<0)"] eq "True" } {
         set violating_min_reports "$violating_min_reports $report"
     }
-    if { [expr $vio < $min_vio] } { set min_vio "$vio" }
+    set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
 }
-if { "$min_vio" ne "0" } {
+if { [exec python3 -c "print($min_vio<0)"] eq "True" } {
     set min_reg_to_reg_result "vio($min_vio)"
 }
 
@@ -347,12 +347,12 @@ set min_vio "0"
 set violating_max_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_max $report]
-    if { [expr $vio != 0] } {
+    if { [exec python3 -c "print($vio<0)"] eq "True" } {
         set violating_max_reports "$violating_max_reports $report"
     }
-    if { [expr $vio < $min_vio] } { set min_vio "$vio" }
+    set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
 }
-if { "$min_vio" ne "0" } {
+if { [exec python3 -c "print($min_vio<0)"] eq "True" } {
     set max_reg_to_reg_result "vio($min_vio)"
 }
 

--- a/scripts/openroad/timing_top.tcl
+++ b/scripts/openroad/timing_top.tcl
@@ -70,35 +70,37 @@ proc check_reg_to_reg_max {report} {
 
 set reports ""
 
-run_puts_logs "report_checks \\
-    -path_delay min \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -group_count 10000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -endpoint_count 10 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/min.rpt"
-lappend reports "${logs_path}/min.rpt"
-
-run_puts_logs "report_checks \\
-    -path_delay max \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -group_count 10000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -endpoint_count 10 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/max.rpt"
-lappend reports "${logs_path}/max.rpt"
 
 if {!$::env(TIMING_USER_REPORTS)} {
+
+    run_puts_logs "report_checks \\
+        -path_delay min \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -group_count 10000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -endpoint_count 10 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/min.rpt"
+    lappend reports "${logs_path}/min.rpt"
+
+    run_puts_logs "report_checks \\
+        -path_delay max \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -group_count 10000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -endpoint_count 10 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/max.rpt"
+    lappend reports "${logs_path}/max.rpt"
+
     run_puts_logs "report_checks \\
         -path_delay min \\
         -format full_clock_expanded \\
@@ -182,35 +184,36 @@ if {!$::env(TIMING_USER_REPORTS)} {
         "\
         "${logs_path}/soc-max.rpt"
     lappend reports "${logs_path}/soc-max.rpt"
+
+    run_puts_logs "report_checks \\
+        -path_delay min \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/clk-min.rpt"
+    lappend reports "${logs_path}/clk-min.rpt"
+
+    run_puts_logs "report_checks \\
+        -path_delay max \\
+        -format full_clock_expanded \\
+        -fields {slew cap input_pins nets fanout} \\
+        -no_line_splits \\
+        -path_group clk \\
+        -group_count 1000 \\
+        -slack_max 10 \\
+        -digits 2 \\
+        -unique_paths_to_endpoint \\
+        "\
+        "${logs_path}/clk-max.rpt"
+    lappend reports "${logs_path}/clk-max.rpt"
 }
 
-run_puts_logs "report_checks \\
-    -path_delay min \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/clk-min.rpt"
-lappend reports "${logs_path}/clk-min.rpt"
-
-run_puts_logs "report_checks \\
-    -path_delay max \\
-    -format full_clock_expanded \\
-    -fields {slew cap input_pins nets fanout} \\
-    -no_line_splits \\
-    -path_group clk \\
-    -group_count 1000 \\
-    -slack_max 10 \\
-    -digits 2 \\
-    -unique_paths_to_endpoint \\
-    "\
-    "${logs_path}/clk-max.rpt"
-lappend reports "${logs_path}/clk-max.rpt"
 
 run_puts_logs "report_checks \\
     -path_delay min \\

--- a/scripts/trim_violators.py
+++ b/scripts/trim_violators.py
@@ -20,7 +20,7 @@ def trim(stream, endpoints):
         if done:
             break
         if "VIOLATED" in line:
-            if "mprj" in line:
+            if "mprj/" or "mprj." in line:
                 lines.append(line)
                 violated = True
         else:

--- a/scripts/trim_violators.py
+++ b/scripts/trim_violators.py
@@ -20,7 +20,7 @@ def trim(stream, endpoints):
         if done:
             break
         if "VIOLATED" in line:
-            if "mprj/" or "mprj." in line:
+            if "mprj/" in line or "mprj." in line:
                 lines.append(line)
                 violated = True
         else:

--- a/scripts/trim_violators.py
+++ b/scripts/trim_violators.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+from report import Report
+import click
+import re
+import textwrap
+
+
+def trim(stream, endpoints):
+    lines = []
+    done = False
+    violated = False
+    last_pos = stream.tell()
+    line = stream.readline()
+    while line != '':
+        for endpoint in endpoints:
+            if endpoint in line:
+                done = True
+
+        if done:
+            break
+        if "VIOLATED" in line:
+            if "mprj" in line:
+                lines.append(line)
+                violated = True
+        else:
+            lines.append(line)
+        last_pos = stream.tell()
+        line = stream.readline()
+
+    stream.seek(last_pos)
+
+    if not violated:
+        lines = []
+
+    return lines
+
+@click.command()
+@click.option(
+    "--input",
+    "-i",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="sta report",
+)
+@click.option(
+    "--output",
+    "-o",
+    required=True,
+    type=click.Path(dir_okay=False),
+    help="sta report",
+)
+def main(input, output):
+    lines = []
+    keywords = ["max slew", "max capacitance", "min_delay/hold", "max_delay/setup"]
+    append = True
+    input_stream = open(input)
+    line = input_stream.readline()
+    while line != '':
+        for keyword in keywords:
+            if keyword in line:
+                print(keyword)
+                trimmed = trim(input_stream, keywords)
+                if trimmed:
+                    lines += line
+                    lines += trimmed
+                append = False
+        if append:
+            lines.append(line)
+        line = input_stream.readline()
+        append = True
+
+    with open(output, "w") as output_stream:
+        output_stream.writelines(lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/timing.mk
+++ b/timing.mk
@@ -7,6 +7,7 @@ export ALLOW_MISSING_SPEF ?= 1
 export PDK_REF_PATH = $(PDK_ROOT)/$(PDK)/libs.ref/
 export PDK_TECH_PATH = $(PDK_ROOT)/$(PDK)/libs.tech/
 export PROJECT_ROOT ?= $(CARAVEL_ROOT)
+export TIMING_USER_REPORTS ?= 0
 
 logs-dir = $(PROJECT_ROOT)/logs
 logs = $(logs-dir)/rcx $(logs-dir)/sdf $(logs-dir)/top $(logs-dir)/sta
@@ -30,6 +31,7 @@ define docker_run_base
 		-e PDK_REF_PATH=$(PDK_ROOT)/$(PDK)/libs.ref/ \
 		-e PDK_TECH_PATH=$(PDK_ROOT)/$(PDK)/libs.tech/ \
 		-e ALLOW_MISSING_SPEF=$(ALLOW_MISSING_SPEF) \
+		-e TIMING_USER_REPORTS=$(TIMING_USER_REPORTS) \
 		-v $(PDK_ROOT):$(PDK_ROOT) \
 		-v $(CUP_ROOT):$(CUP_ROOT) \
 		-v $(MCW_ROOT):$(MCW_ROOT) \
@@ -88,12 +90,12 @@ defs += $(shell cd $(CUP_ROOT)/def && find *.def -maxdepth 0 -type f)
 endif
 
 rcx-blocks     = $(defs:%.def=rcx-%)
-rcx-blocks-nom = $(blocks:%=rcx-%-nom)
-rcx-blocks-max = $(blocks:%=rcx-%-max)
-rcx-blocks-min = $(blocks:%=rcx-%-min)
-rcx-blocks-t = $(blocks:%=rcx-%-t)
-rcx-blocks-f = $(blocks:%=rcx-%-f)
-rcx-blocks-s = $(blocks:%=rcx-%-s)
+rcx-blocks-nom = $(defs:%.def=rcx-%-nom)
+rcx-blocks-max = $(defs:%.def=rcx-%-max)
+rcx-blocks-min = $(defs:%.def=rcx-%-min)
+rcx-blocks-t = $(defs:%.def=rcx-%-t)
+rcx-blocks-f = $(defs:%.def=rcx-%-f)
+rcx-blocks-s = $(defs:%.def=rcx-%-s)
 
 sdf-blocks = $(blocks:%=sdf-%)
 sdf-blocks-t = $(blocks:%=sdf-%-t)
@@ -156,6 +158,7 @@ $(sta-blocks-s): sta-%-s:
 $(sta-blocks-f): sta-%-f:
 	$(call docker_run_sta,$*)
 
+rcx-requirements  = $(CARAVEL_ROOT)/def/%.def
 
 $(rcx-blocks): rcx-%: $(rcx-requirements)
 	$(MAKE) -f timing.mk rcx-$*-nom &
@@ -243,11 +246,6 @@ $(caravel-timing-targets): $(logs-dir)/top
 
 # some useful dev double checking
 #
-rcx-requirements  = $(CARAVEL_ROOT)/def/%.def
-rcx-requirements += $(CARAVEL_ROOT)/lef/%.lef
-rcx-requirements += $(CARAVEL_ROOT)/sdc/%.sdc
-rcx-requirements += $(CARAVEL_ROOT)/verilog/gl/%.v
-
 exceptions  = $(MCW_ROOT)/lef/caravel.lef
 exceptions += $(MCW_ROOT)/lef/caravan.lef
 # lets ignore these for now
@@ -274,22 +272,22 @@ $(exceptions):
 $(CARAVEL_ROOT)/def/%.def: $(MCW_ROOT)/def/%.def ;
 $(MCW_ROOT)/def/%.def: $(CUP_ROOT)/def/%.def ;
 $(CUP_ROOT)/def/%.def:
-	$(error error if you are here it probably means that $@.def is mising from mcw and caravel)
+	$(error error if you are here it probably means that $@ is mising from mcw and caravel)
 
 $(CARAVEL_ROOT)/lef/%.lef: $(MCW_ROOT)/lef/%.lef ;
 $(MCW_ROOT)/lef/%.lef: $(CUP_ROOT)/lef/%.lef ;
 $(CUP_ROOT)/lef/%.lef:
-	$(error error if you are here it probably means that $@.lef is mising from mcw and caravel)
+	$(error error if you are here it probably means that $@ is mising from mcw and caravel)
 
 $(CARAVEL_ROOT)/sdc/%.sdc: $(MCW_ROOT)/sdc/%.sdc ;
 $(MCW_ROOT)/sdc/%.sdc: $(CUP_ROOT)/sdc/%.sdc ;
 $(CUP_ROOT)/sdc/%.sdc:
-	$(error error if you are here it probably means that $@.sdc is mising from mcw and caravel)
+	$(error error if you are here it probably means that $@ is mising from mcw and caravel)
 
 $(CARAVEL_ROOT)/verilog/gl/%.v: $(MCW_ROOT)/verilog/gl/%.v ;
 $(MCW_ROOT)/verilog/gl/%.v: $(CUP_ROOT)/verilog/gl/%.v ;
 $(CUP_ROOT)/verilog/gl/%.v:
-	$(error error if you are here it probably means that gl/$@.v is mising from mcw and caravel)
+	$(error error if you are here it probably means that $@ is mising from mcw and caravel)
 
 check_defined = \
     $(strip $(foreach 1,$1, \
@@ -305,3 +303,9 @@ $(call check_defined, \
 	CARAVEL_ROOT \
 	TIMING_ROOT \
 )
+
+.PHONY: clean-timing-top
+clean-timing-top:
+	rm -rf $(logs-dir)/top
+	rm -rf $(PROJECT_ROOT)/signoff/caravel/openlane-signoff/timing/ -r
+

--- a/timing.mk
+++ b/timing.mk
@@ -7,7 +7,7 @@ export ALLOW_MISSING_SPEF ?= 1
 export PDK_REF_PATH = $(PDK_ROOT)/$(PDK)/libs.ref/
 export PDK_TECH_PATH = $(PDK_ROOT)/$(PDK)/libs.tech/
 export PROJECT_ROOT ?= $(CARAVEL_ROOT)
-export TIMING_USER_REPORTS ?= 0
+export TIMING_USER_REPORTS ?= 1
 
 logs-dir = $(PROJECT_ROOT)/logs
 logs = $(logs-dir)/rcx $(logs-dir)/sdf $(logs-dir)/top $(logs-dir)/sta


### PR DESCRIPTION
\- remove `simple_por` from spef mapping file
\- remove redundant python imports

\~ rcx blocks are now dependent on def files 

\+ add hvl lef and techlef for sky130
\+ add `get_worst.py` that reports the worst negative slack in a given timing report
\+ add `TIMING_USER_REPORTS` which limits the number of reports generated for the users
\+ add `clean-timing-top` make target that remove logs and reports generated by timing top
\+ add `trim_violators.py` a script to trim summary report to user violations only