### PR TITLE
Only glob verilog files with `.v` extension

### DIFF
--- a/env/common.tcl
+++ b/env/common.tcl
@@ -57,9 +57,9 @@ set caravel_root "[file normalize $::env(CARAVEL_ROOT)]"
 set mcw_root "[file normalize $::env(MCW_ROOT)]"
 set cup_root "[file normalize $::env(CUP_ROOT)]"
 set verilogs [concat \
-[glob $mcw_root/verilog/gl/*] \
-[glob $caravel_root/verilog/gl/*] \
-[glob $cup_root/verilog/gl/*] \
+[glob $mcw_root/verilog/gl/*.v] \
+[glob $caravel_root/verilog/gl/*.v] \
+[glob $cup_root/verilog/gl/*.v] \
 ]
 
 set verilog_exceptions [list \


### PR DESCRIPTION
 ~ update GL list `verilogs` to be any file with the extension `.v`
 * this is required as the current caravel repo ([d596b4a](https://github.com/efabless/caravel/commit/d596b4a9deb9db09bf70a95fa4a50e3f64437de2)) inlcudes `.txt` in the gl directory which breaks the `caravel-sta` run