### PR TITLE
Fix scripts issues

### DIFF
--- a/env/sky130A/config.tcl
+++ b/env/sky130A/config.tcl
@@ -32,3 +32,4 @@ set pdk(lefs) [list \
 set pdk(rcx_rules_file) $::env(PDK_TECH_PATH)/openlane/rules.openrcx.$::env(PDK).$::env(RCX_CORNER).calibre
 
 source $::env(TIMING_ROOT)/env/$::env(PDK)/$::env(LIB_CORNER).tcl
+source $::env(TIMING_ROOT)/env/caravel_spef_mapping-mpw9.tcl

--- a/scripts/get_violations.py
+++ b/scripts/get_violations.py
@@ -29,7 +29,7 @@ def main(input, append, type):
     for category, paths in paths_dict.items():
         filtered_paths = filter_paths(paths, type)
         violating_paths = filter_violating(filtered_paths)
-        if violating_paths != []:
+        if violating_paths != [] and category == "reg-reg":
             max_vio = min(min(violating_paths, key=lambda x: x.slack).slack, max_vio)
         result += f"{category}: {len(violating_paths)}/{len(filtered_paths)}\n"
 

--- a/scripts/get_violations.py
+++ b/scripts/get_violations.py
@@ -11,11 +11,12 @@ def filter_violating(paths):
 @click.command()
 @click.option("--append", "-a", is_flag=True)
 @click.option("--type", required=True, type=click.Choice(["min", "max"]))
+@click.option("--category", type=click.Choice(["reg-reg", "reg-output", "input-reg", "input-output"]), default="reg-reg")
 @click.argument(
     "input",
     type=click.Path(exists=True, dir_okay=False),
 )
-def main(input, append, type):
+def main(input, append, type, category):
     report = Report(input)
     max_vio = 0
     paths_dict = {
@@ -26,12 +27,12 @@ def main(input, append, type):
     }
     result = f"{type}:\n"
 
-    for category, paths in paths_dict.items():
+    for sp_ep_pair, paths in paths_dict.items():
         filtered_paths = filter_paths(paths, type)
         violating_paths = filter_violating(filtered_paths)
-        if violating_paths != [] and category == "reg-reg":
+        if violating_paths != [] and sp_ep_pair == category:
             max_vio = min(min(violating_paths, key=lambda x: x.slack).slack, max_vio)
-        result += f"{category}: {len(violating_paths)}/{len(filtered_paths)}\n"
+        result += f"{sp_ep_pair}: {len(violating_paths)}/{len(filtered_paths)}\n"
 
     if append:
         with open(input, "a") as stream:

--- a/scripts/openroad/timing_top.tcl
+++ b/scripts/openroad/timing_top.tcl
@@ -230,19 +230,12 @@ if {!$::env(TIMING_USER_REPORTS)} {
 
     set summary_report ${logs_path}/summary.log
     run_puts_logs "report_check_types \\
-        -max_slew \\
-        -max_capacitance \\
         -format end \\
         -violators" \
         "${summary_report}"
 
     set worst_hold "[exec python3 $::env(TIMING_ROOT)/scripts/get_worst.py -i ${logs_path}/min.rpt]"
     set worst_setup "[exec python3 $::env(TIMING_ROOT)/scripts/get_worst.py -i ${logs_path}/max.rpt]"
-
-    exec python3 $::env(TIMING_ROOT)/scripts/generate_async_paths_summary.py \
-        --min ${logs_path}/min.rpt \
-        --max ${logs_path}/max.rpt \
-        -o $summary_report -a
 
 } else {
 
@@ -278,6 +271,8 @@ if {!$::env(TIMING_USER_REPORTS)} {
     run_puts_logs "report_check_types \\
         -max_slew \\
         -max_capacitance \\
+        -recovery \\
+        -removal \\
         -format end \\
         -violators" \
         "${summary_report}"
@@ -289,10 +284,6 @@ if {!$::env(TIMING_USER_REPORTS)} {
     set worst_hold "[exec python3 $::env(TIMING_ROOT)/scripts/get_worst.py -i ${logs_path}/mprj-min.rpt]"
     set worst_setup "[exec python3 $::env(TIMING_ROOT)/scripts/get_worst.py -i ${logs_path}/mprj-max.rpt]"
 
-    exec python3 $::env(TIMING_ROOT)/scripts/generate_async_paths_summary.py \
-        --min ${logs_path}/mprj-min.rpt \
-        --max ${logs_path}/mprj-max.rpt \
-        -o $summary_report -a
 }
 
 
@@ -347,10 +338,10 @@ set min_vio "0"
 set violating_min_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_min $report]
-    if { [exec python3 -c "print($vio<0)"] eq "True" } {
+    if { $vio } {
         set violating_min_reports "$violating_min_reports $report"
+        set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
     }
-    set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
 }
 if { [exec python3 -c "print($min_vio<0)"] eq "True" } {
     set min_reg_to_reg_result "vio($min_vio)"
@@ -361,10 +352,10 @@ set min_vio "0"
 set violating_max_reports ""
 foreach report $reports {
     set vio [check_reg_to_reg_max $report]
-    if { [exec python3 -c "print($vio<0)"] eq "True" } {
+    if { $vio } {
         set violating_max_reports "$violating_max_reports $report"
+        set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
     }
-    set min_vio [exec python3 -c "print(f'{min($vio, $min_vio):.2f}')"]
 }
 if { [exec python3 -c "print($min_vio<0)"] eq "True" } {
     set max_reg_to_reg_result "vio($min_vio)"

--- a/scripts/openroad/timing_top.tcl
+++ b/scripts/openroad/timing_top.tcl
@@ -1,5 +1,4 @@
 source $::env(TIMING_ROOT)/env/common.tcl
-source $::env(TIMING_ROOT)/env/caravel_spef_mapping-mpw9.tcl
 
 if { [file exists $::env(CUP_ROOT)/env/spef-mapping.tcl] } {
     source $::env(CUP_ROOT)/env/spef-mapping.tcl

--- a/scripts/timing_path.py
+++ b/scripts/timing_path.py
@@ -88,7 +88,7 @@ class TimingPath:
 
     def find_category(self):
         start = "input" if "input" in self.start_point else "reg"
-        end = "input" if "input" in self.end_point else "reg"
+        end = "output" if "output" in self.end_point else "reg"
 
         self.category = f"{start}-{end}"
 


### PR DESCRIPTION
update `timing_path.py`:
~ fix typo in `find_category` method where the endpoint is categorized based on `input` instead of `output`

update `get_violations.py`:
~ the script is required to return the worst `reg-reg` slack to [timing_top.tcl](https://github.com/efabless/timing-scripts/blob/main/scripts/openroad/timing_top.tcl) (it was returning the worst slack overall)

update `timing_top.tcl`:
~ to match the latest `get_violations.py`
~ for async paths, use `report_check_types` arguments
~ report all violators in the summary report when `TIMING_USER_REPORTS` is unset
~ move caravel spef mapping to PDK specific configurations