### PR TITLE
Fix loading of gf180mcu* srams

### DIFF
--- a/env/gf180mcuC/config.tcl
+++ b/env/gf180mcuC/config.tcl
@@ -12,14 +12,14 @@ set sram_lefs [list \
     $::env(PDK_REF_PATH)/gf180mcu_fd_ip_sram/lef/gf180mcu_fd_ip_sram__sram512x8m8wm1.lef \
     $::env(PDK_REF_PATH)/gf180mcu_fd_ip_sram/lef/gf180mcu_fd_ip_sram__sram64x8m8wm1.lef
 ]
-
-
 set pdk(lefs) [list \
     $tech_lef \
     $cells_lef \
-    $io_lef \
-    $sram_lefs
+    $io_lef 
 ]
+foreach lef $sram_lefs {
+    lappend pdk(lefs) $lef
+}
 
 set pdk(rcx_rules_file) $::env(PDK_TECH_PATH)/openlane/rules.openrcx.$::env(PDK).$::env(RCX_CORNER)
 

--- a/env/gf180mcuD/config.tcl
+++ b/env/gf180mcuD/config.tcl
@@ -12,13 +12,14 @@ set sram_lefs [list \
     $::env(PDK_REF_PATH)/gf180mcu_fd_ip_sram/lef/gf180mcu_fd_ip_sram__sram512x8m8wm1.lef \
     $::env(PDK_REF_PATH)/gf180mcu_fd_ip_sram/lef/gf180mcu_fd_ip_sram__sram64x8m8wm1.lef
 ]
-
 set pdk(lefs) [list \
     $tech_lef \
     $cells_lef \
-    $io_lef \
-    $sram_lefs
+    $io_lef 
 ]
+foreach lef $sram_lefs {
+    lappend pdk(lefs) $lef
+}
 
 set pdk(rcx_rules_file) $::env(PDK_TECH_PATH)/openlane/rules.openrcx.$::env(PDK).$::env(RCX_CORNER)
 

--- a/scripts/openroad/rcx.tcl
+++ b/scripts/openroad/rcx.tcl
@@ -6,7 +6,6 @@ foreach liberty $pdk(libs) {
 foreach lef $pdk(lefs) {
   run_puts "read_lef $lef"
 }
-run_puts "read_lef $sram_lef"
 
 foreach lef_file $extra_lefs {		
   run_puts "read_lef $lef_file"


### PR DESCRIPTION
~ gf180mcu `sram_lefs` should be added one by one to the `pdk(lefs)` list
- remove duplicate reading of the `sram_lef`. Once in the `pdk(lefs)` and once standalone 